### PR TITLE
[STEP 12] 이커머스 동시성 제어 방식 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,28 +30,36 @@ dependencyManagement {
 }
 
 dependencies {
-    // Spring
+	// Spring
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("org.springframework.boot:spring-boot-starter-validation:3.4.1")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("jakarta.validation:jakarta.validation-api:3.0.0")
 
-	// swagger
+	// Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0")
 
-    // DB
+	// Redis
+	implementation("org.redisson:redisson-spring-boot-starter:3.43.0")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+	// Database
 	runtimeOnly("com.mysql:mysql-connector-j")
 
-	annotationProcessor("org.projectlombok:lombok")
+	// Lombok
 	compileOnly("org.projectlombok:lombok")
+	annotationProcessor("org.projectlombok:lombok")
+	testCompileOnly("org.projectlombok:lombok")
+	testAnnotationProcessor("org.projectlombok:lombok")
 
-    // Test
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+	// Test
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
 }
 
 tasks.withType<Test> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  redis:
+    image: redis:7.4.2
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./data/redis:/data  # Redis 데이터
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/commerce/app/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/commerce/app/CouponFacade.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.commerce.app;
 
 import kr.hhplus.be.commerce.app.dto.CouponResponse;
 import kr.hhplus.be.commerce.domain.coupon.CouponService;
+import kr.hhplus.be.commerce.domain.lock.DistributedLock;
 import kr.hhplus.be.commerce.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,8 @@ public class CouponFacade {
     private final CouponService couponService;
     private final UserService userService;
 
+
+    @DistributedLock(key = "'coupon:quantity:' + #couponId")
     public Long issueCoupon(Long userId, Long couponId) {
 
         userService.checkUserExists(userId);

--- a/src/main/java/kr/hhplus/be/commerce/domain/balance/Balance.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/balance/Balance.java
@@ -29,6 +29,11 @@ public class Balance extends AuditingFields implements Serializable {
     @Comment("금액")
     private Long amount;
 
+    @Version
+    @Column(name = "version", nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    @Comment("버전")
+    private Long version;
+
     public static Balance create(Long userId, Long amount) {
         Balance entity = new Balance();
         entity.userId = userId;

--- a/src/main/java/kr/hhplus/be/commerce/domain/coupon/CouponQuantityRepository.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/coupon/CouponQuantityRepository.java
@@ -1,5 +1,5 @@
 package kr.hhplus.be.commerce.domain.coupon;
 
 public interface CouponQuantityRepository {
-    CouponQuantity findByIdWithLock(Long couponId);
+    Long updateCouponQuantityWithLock(Long couponId);
 }

--- a/src/main/java/kr/hhplus/be/commerce/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/coupon/CouponService.java
@@ -85,12 +85,10 @@ public class CouponService {
     }
 
     public Long updateCouponQuantity(Long couponId) {
-        CouponQuantity couponQuantity = couponQuantityRepository.findByIdWithLock(couponId);
-        long decrementedQuantity = couponQuantity.getRemainingQuantity() - 1;
+        long decrementedQuantity = couponQuantityRepository.updateCouponQuantityWithLock(couponId);
         if(decrementedQuantity < 0) {
             throw new BusinessException(BusinessErrorCode.OUT_OF_COUPONS);
         }
-        couponQuantity.changeRemainingQuantity(decrementedQuantity);
         return decrementedQuantity;
     }
 

--- a/src/main/java/kr/hhplus/be/commerce/domain/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/lock/DistributedLock.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.commerce.domain.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+}

--- a/src/main/java/kr/hhplus/be/commerce/infra/config/CouponQuantityRepositoryConfig.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/config/CouponQuantityRepositoryConfig.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.commerce.infra.config;
+
+import kr.hhplus.be.commerce.domain.coupon.CouponQuantityRepository;
+import kr.hhplus.be.commerce.infra.coupon.CouponQuantityJpaRepository;
+import kr.hhplus.be.commerce.infra.coupon.CouponQuantityRepositoryImpl;
+import kr.hhplus.be.commerce.infra.coupon.RedisCouponQuantityRepositoryImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CouponQuantityRepositoryConfig {
+
+    //TODO : 테스트를 위한 config로, 추후 적절한 코드만 남기고 제거 예정
+    @Bean(name = "redisCouponQuantityRepository")
+    @Primary // 기본으로 RedisCouponQuantityRepositoryImpl 사용
+    public CouponQuantityRepository redisCouponQuantityRepository(
+            CouponQuantityJpaRepository couponQuantityJpaRepository) {
+        return new RedisCouponQuantityRepositoryImpl(couponQuantityJpaRepository);
+    }
+
+    @Bean(name = "jpaCouponQuantityRepository")
+    // 테스트에서 직접 주입
+    public CouponQuantityRepository jpaCouponQuantityRepository(
+            CouponQuantityJpaRepository couponQuantityJpaRepository) {
+        return new CouponQuantityRepositoryImpl(couponQuantityJpaRepository);
+    }
+}

--- a/src/main/java/kr/hhplus/be/commerce/infra/config/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.commerce.infra.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${redis.port:6379}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://" + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+}

--- a/src/main/java/kr/hhplus/be/commerce/infra/coupon/CouponQuantityJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/coupon/CouponQuantityJpaRepository.java
@@ -18,4 +18,8 @@ public interface CouponQuantityJpaRepository extends JpaRepository<CouponQuantit
     })
     @Query("SELECT c FROM CouponQuantity c WHERE c.couponId = :couponId")
     Optional<CouponQuantity> findByCouponIdWithLock(@Param("couponId") Long couponId);
+
+
+    @Query("SELECT c FROM CouponQuantity c WHERE c.couponId = :couponId")
+    Optional<CouponQuantity> findByCouponId(@Param("couponId") Long couponId);
 }

--- a/src/main/java/kr/hhplus/be/commerce/infra/coupon/CouponQuantityRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/coupon/CouponQuantityRepositoryImpl.java
@@ -15,7 +15,14 @@ public class CouponQuantityRepositoryImpl implements CouponQuantityRepository {
     private final CouponQuantityJpaRepository couponQuantityJpaRepository;
 
     @Override
-    public CouponQuantity findByIdWithLock(Long couponId) {
+    public Long updateCouponQuantityWithLock(Long couponId) {
+        CouponQuantity couponQuantity = findByCouponIdWithLock(couponId);
+        long decrementedQuantity = couponQuantity.getRemainingQuantity() - 1;
+        couponQuantity.changeRemainingQuantity(decrementedQuantity);
+        return decrementedQuantity;
+    }
+
+    private CouponQuantity findByCouponIdWithLock(Long couponId) {
         try {
             return couponQuantityJpaRepository.findByCouponIdWithLock(couponId)
                     .orElseThrow(() -> new BusinessException(BusinessErrorCode.COUPON_QUANTITY_NOT_FOUND));

--- a/src/main/java/kr/hhplus/be/commerce/infra/coupon/UserCouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/coupon/UserCouponRepositoryImpl.java
@@ -24,7 +24,7 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
 
     @Override
     public Long save(UserCoupon userCoupon) {
-        return userCouponJpaRepository.save(userCoupon).getCouponId();
+        return userCouponJpaRepository.save(userCoupon).getUserCouponId();
     }
 
     @Override

--- a/src/main/java/kr/hhplus/be/commerce/infra/lock/AopForTransaction.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/lock/AopForTransaction.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.commerce.infra.lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/kr/hhplus/be/commerce/infra/lock/CustomSpringELParser.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/lock/CustomSpringELParser.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.commerce.infra.lock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/commerce/infra/lock/DistributedLockAspect.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/lock/DistributedLockAspect.java
@@ -1,0 +1,50 @@
+package kr.hhplus.be.commerce.infra.lock;
+
+import kr.hhplus.be.commerce.domain.lock.DistributedLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedisLockManager redisLockManager;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(kr.hhplus.be.commerce.domain.lock.DistributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                distributedLock.key()
+        );
+
+        log.info("Acquiring lock with key: {}", key);
+
+        return redisLockManager.executeWithLock(
+                key,
+                () -> {
+                    try {
+                        return aopForTransaction.proceed(joinPoint);
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/commerce/infra/lock/RedisLockManager.java
+++ b/src/main/java/kr/hhplus/be/commerce/infra/lock/RedisLockManager.java
@@ -1,0 +1,61 @@
+package kr.hhplus.be.commerce.infra.lock;
+
+import kr.hhplus.be.commerce.domain.error.BusinessErrorCode;
+import kr.hhplus.be.commerce.domain.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockManager {
+
+    private final RedissonClient redissonClient;
+
+    private static final long DEFAULT_LOCK_WAIT_TIME = 5L;
+    private static final long DEFAULT_LOCK_LEASE_TIME = 10L;
+
+    public <T> T executeWithLock(String key, LockCallback<T> callback) {
+        return executeWithLock(key, DEFAULT_LOCK_WAIT_TIME, DEFAULT_LOCK_LEASE_TIME, callback);
+    }
+
+    public <T> T executeWithLock(String key, long waitTime, long leaseTime, LockCallback<T> callback) {
+        RLock lock = redissonClient.getLock(key);
+        if (!tryAcquireLock(lock, waitTime, leaseTime)) {
+            throw new BusinessException(BusinessErrorCode.LOCK_TIMEOUT);
+        }
+
+        try {
+            return callback.doWithLock();
+        } finally {
+            releaseLock(lock);
+        }
+    }
+
+    private boolean tryAcquireLock(RLock lock, long waitTime, long leaseTime) {
+        try {
+            return lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(BusinessErrorCode.LOCK_TIMEOUT);
+        }
+    }
+
+    private void releaseLock(RLock lock) {
+        if (lock.isHeldByCurrentThread()) {
+            try {
+                lock.unlock();
+            } catch (IllegalMonitorStateException e) {
+            }
+        }
+    }
+
+
+    @FunctionalInterface
+    public interface LockCallback<T> {
+        T doWithLock();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,16 +22,21 @@ spring:
       hibernate.jdbc.time_zone: UTC
   springdoc:
     api-docs:
-      enabled: true   # OpenAPI 문서 활성화
+      enabled: true
     swagger-ui:
-      enabled: true   # Swagger UI 활성화
-      path: /swagger-ui.html  # Swagger UI 경로 (기본값은 swagger-ui.html)
+      enabled: true
+      path: /swagger-ui.html
 
 ---
 spring.config.activate.on-profile: local, test
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://mysql:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+
+  data:
+    redis:
+      host: redis
+      port: 6379

--- a/src/test/java/kr/hhplus/be/commerce/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/commerce/TestcontainersConfiguration.java
@@ -2,30 +2,59 @@ package kr.hhplus.be.commerce;
 
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
 
 @Configuration
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
+
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-			.withDatabaseName("hhplus")
-			.withUsername("test")
-			.withPassword("test");
+				.withDatabaseName("hhplus")
+				.withUsername("test")
+				.withPassword("test");
 		MYSQL_CONTAINER.start();
 
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		// Redis 컨테이너 설정
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:7.4.2"))
+				.withExposedPorts(6379);
+
+		REDIS_CONTAINER.setPortBindings(List.of("6379:6379"));
+
+		REDIS_CONTAINER.start();
+
 	}
+
+	@DynamicPropertySource
+	static void registerRedisProperties(DynamicPropertyRegistry registry) {
+		String redisHost = REDIS_CONTAINER.getHost();
+		Integer redisPort = REDIS_CONTAINER.getFirstMappedPort();
+
+		registry.add("spring.data.redis.host", () -> redisHost);
+		registry.add("spring.data.redis.port", () -> redisPort);
+	}
+
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/commerce/app/BalanceConcurrencyIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/commerce/app/BalanceConcurrencyIntegrationTest.java
@@ -1,0 +1,54 @@
+package kr.hhplus.be.commerce.app;
+
+import kr.hhplus.be.commerce.domain.balance.Balance;
+import kr.hhplus.be.commerce.domain.user.User;
+import kr.hhplus.be.commerce.utils.IntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static kr.hhplus.be.commerce.utils.TestUtils.createTestUser;
+
+class BalanceConcurrencyIntegrationTest extends IntegrationTest {
+    @Autowired
+    private BalanceFacade balanceFacade;
+
+    @Test
+    @DisplayName("잔액 충전 더블클릭 테스트")
+    void charge_ConcurrentRequests_ShouldHandleCorrectly() {
+        // given
+        User user = createTestUser();
+        userJpaRepository.save(user);
+
+        long initialBalance = 2000L;
+        Balance balance = Balance.create(user.getUserId(), initialBalance);
+        balanceJpaRepository.save(balance);
+
+        long userId = user.getUserId();
+        long chargeAmount = 500L;
+
+        // when
+        Runnable task = () -> balanceFacade.charge(userId, chargeAmount);
+
+        Thread thread1 = new Thread(task);
+        Thread thread2 = new Thread(task);
+
+        thread1.start();
+        thread2.start();
+
+        try {
+            thread1.join();
+            thread2.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+
+        // then
+        Balance updatedBalance = balanceRepository.findByUserId(userId);
+        Assertions.assertNotNull(updatedBalance);
+        Assertions.assertEquals(initialBalance + chargeAmount, updatedBalance.getAmount());
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/commerce/app/CouponConcurrencyPerformanceTest.java
+++ b/src/test/java/kr/hhplus/be/commerce/app/CouponConcurrencyPerformanceTest.java
@@ -1,0 +1,181 @@
+package kr.hhplus.be.commerce.app;
+
+import kr.hhplus.be.commerce.domain.coupon.Coupon;
+import kr.hhplus.be.commerce.domain.coupon.CouponQuantity;
+import kr.hhplus.be.commerce.domain.error.BusinessErrorCode;
+import kr.hhplus.be.commerce.domain.error.BusinessException;
+import kr.hhplus.be.commerce.domain.user.User;
+import kr.hhplus.be.commerce.infra.coupon.CouponJpaRepository;
+import kr.hhplus.be.commerce.infra.coupon.CouponQuantityJpaRepository;
+import kr.hhplus.be.commerce.infra.coupon.UserCouponJpaRepository;
+import kr.hhplus.be.commerce.infra.user.UserJpaRepository;
+import kr.hhplus.be.commerce.utils.CouponFacadeLockTestConfig;
+import kr.hhplus.be.commerce.utils.PerformanceMeasure;
+import kr.hhplus.be.commerce.utils.TestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.*;
+
+@Import(CouponFacadeLockTestConfig.class)
+@SpringBootTest
+@ActiveProfiles("test")
+class CouponConcurrencyPerformanceTest {
+
+    @Autowired
+    @Qualifier("redisCouponFacade")
+    private CouponFacade redisCouponFacade;
+
+    @Autowired
+    @Qualifier("jpaCouponFacade")
+    private CouponFacade jpaCouponFacade;
+
+    @Autowired
+    protected UserJpaRepository userJpaRepository;
+    @Autowired
+    protected CouponJpaRepository couponJpaRepository;
+    @Autowired
+    protected CouponQuantityJpaRepository couponQuantityJpaRepository;
+    @Autowired
+    protected UserCouponJpaRepository userCouponJpaRepository;
+
+    @BeforeEach
+    void init() {
+        userCouponJpaRepository.deleteAllInBatch();
+        couponQuantityJpaRepository.deleteAllInBatch();
+        couponJpaRepository.deleteAllInBatch();
+        userJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("JPA 비관적 락 기반 쿠폰발급 동시성 제어 성능 측정")
+    void measureJpaLockPerformance() {
+        // given
+        Coupon coupon = TestUtils.createTestCoupon(1L, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(10), 10L);
+        couponJpaRepository.save(coupon);
+
+        CouponQuantity couponQuantity = CouponQuantity.create(coupon.getCouponId(), 10L);
+        couponQuantityJpaRepository.save(couponQuantity);
+
+        int threadCount = 10;
+
+        List<Future<Long>> futures = new ArrayList<>();
+
+        PerformanceMeasure.measure("Redis Lock", () -> {
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executorService.submit(() -> {
+                    try {
+                        User user = userJpaRepository.save(TestUtils.createTestUser());
+                        return jpaCouponFacade.issueCoupon(user.getUserId(), coupon.getCouponId());
+                    } finally {
+                        latch.countDown();
+                    }
+                }));
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            executorService.shutdown();
+            return null;
+        });
+
+        // then
+        List<Long> issuedCoupons = new ArrayList<>();
+        for (Future<Long> future : futures) {
+            try {
+                issuedCoupons.add(future.get());
+            } catch (ExecutionException | InterruptedException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof BusinessException businessException) {
+                    Assertions.assertEquals(BusinessErrorCode.OUT_OF_COUPONS, businessException.getErrorCode());
+                } else {
+                    throw new RuntimeException(cause);
+                }
+            }
+        }
+
+        long successfulIssues = issuedCoupons.stream().filter(Objects::nonNull).count();
+        Assertions.assertEquals(10, successfulIssues);
+
+        Coupon updatedCoupon = couponJpaRepository.findById(coupon.getCouponId()).orElseThrow();
+        Assertions.assertEquals(0L, updatedCoupon.getCouponQuantity());
+    }
+
+    @Test
+    @DisplayName("Redis 분산락 기반 쿠폰발급 동시성 제어 성능 측정")
+    void measureRedisLockPerformance() {
+        // given
+        Coupon coupon = TestUtils.createTestCoupon(1L, LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(10), 10L);
+        couponJpaRepository.save(coupon);
+
+        CouponQuantity couponQuantity = CouponQuantity.create(coupon.getCouponId(), 10L);
+        couponQuantityJpaRepository.save(couponQuantity);
+
+        int threadCount = 10;
+
+        List<Future<Long>> futures = new ArrayList<>();
+
+        PerformanceMeasure.measure("Redis Lock", () -> {
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executorService.submit(() -> {
+                    try {
+                        User user = userJpaRepository.save(TestUtils.createTestUser());
+                        return redisCouponFacade.issueCoupon(user.getUserId(), coupon.getCouponId());
+                    } finally {
+                        latch.countDown();
+                    }
+                }));
+            }
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            executorService.shutdown();
+            return null;
+        });
+
+        // then
+        List<Long> issuedCoupons = new ArrayList<>();
+        for (Future<Long> future : futures) {
+            try {
+                issuedCoupons.add(future.get());
+            } catch (ExecutionException | InterruptedException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof BusinessException businessException) {
+                    Assertions.assertEquals(BusinessErrorCode.OUT_OF_COUPONS, businessException.getErrorCode());
+                } else {
+                    throw new RuntimeException(cause);
+                }
+            }
+        }
+
+        long successfulIssues = issuedCoupons.stream().filter(Objects::nonNull).count();
+        Assertions.assertEquals(10, successfulIssues);
+
+        Coupon updatedCoupon = couponJpaRepository.findById(coupon.getCouponId()).orElseThrow();
+        Assertions.assertEquals(0L, updatedCoupon.getCouponQuantity());
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/commerce/app/CouponFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/commerce/app/CouponFacadeIntegrationTest.java
@@ -74,6 +74,8 @@ class CouponFacadeIntegrationTest extends IntegrationTest {
         Long userCouponId = couponFacade.issueCoupon(user.getUserId(), coupon.getCouponId());
 
         // then
+        List<UserCoupon> userCoupons = userCouponJpaRepository.findAll();
+        Assertions.assertEquals(userCoupons.size(), 1);
         Optional<UserCoupon> optional = userCouponJpaRepository.findById(userCouponId);
         Assertions.assertTrue(optional.isPresent());
         UserCoupon issuedCoupon = optional.get();

--- a/src/test/java/kr/hhplus/be/commerce/domain/CouponServiceUnitTest.java
+++ b/src/test/java/kr/hhplus/be/commerce/domain/CouponServiceUnitTest.java
@@ -169,10 +169,8 @@ class CouponServiceUnitTest {
     void updateCouponQuantity_ShouldThrowException_WhenOutOfCoupons() {
         // given
         final Long couponId = 1L;
-        CouponQuantity couponQuantity = mock(CouponQuantity.class);
-        when(couponQuantity.getRemainingQuantity()).thenReturn(0L);
 
-        when(couponQuantityRepository.findByIdWithLock(couponId)).thenReturn(couponQuantity);
+        when(couponQuantityRepository.updateCouponQuantityWithLock(couponId)).thenReturn(-1L);
 
         // when
         BusinessException exception = assertThrows(BusinessException.class,

--- a/src/test/java/kr/hhplus/be/commerce/utils/CouponFacadeLockTestConfig.java
+++ b/src/test/java/kr/hhplus/be/commerce/utils/CouponFacadeLockTestConfig.java
@@ -1,0 +1,46 @@
+package kr.hhplus.be.commerce.utils;
+
+import kr.hhplus.be.commerce.app.CouponFacade;
+import kr.hhplus.be.commerce.domain.coupon.CouponQuantityRepository;
+import kr.hhplus.be.commerce.domain.coupon.CouponRepository;
+import kr.hhplus.be.commerce.domain.coupon.CouponService;
+import kr.hhplus.be.commerce.domain.coupon.UserCouponRepository;
+import kr.hhplus.be.commerce.domain.user.UserService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class CouponFacadeLockTestConfig {
+
+    @Bean(name = "redisCouponService")
+    public CouponService redisCouponService(
+            CouponRepository couponRepository,
+            @Qualifier("redisCouponQuantityRepository") CouponQuantityRepository couponQuantityRepository,
+            UserCouponRepository userCouponRepository) {
+        return new CouponService(couponRepository, couponQuantityRepository, userCouponRepository);
+    }
+
+    @Bean(name = "jpaCouponService")
+    public CouponService jpaCouponService(
+            CouponRepository couponRepository,
+            @Qualifier("jpaCouponQuantityRepository") CouponQuantityRepository couponQuantityRepository,
+            UserCouponRepository userCouponRepository) {
+        return new CouponService(couponRepository, couponQuantityRepository, userCouponRepository);
+    }
+
+    @Bean(name = "redisCouponFacade")
+    public CouponFacade redisCouponFacade(
+            @Qualifier("redisCouponService") CouponService couponService,
+            UserService userService) {
+        return new CouponFacade(couponService, userService);
+    }
+
+    @Bean(name = "jpaCouponFacade")
+    public CouponFacade jpaCouponFacade(
+            @Qualifier("jpaCouponService") CouponService couponService,
+            UserService userService) {
+        return new CouponFacade(couponService, userService);
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/commerce/utils/PerformanceMeasure.java
+++ b/src/test/java/kr/hhplus/be/commerce/utils/PerformanceMeasure.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.commerce.utils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Supplier;
+@Slf4j
+public class PerformanceMeasure {
+    public static <T> T measure(String label, Supplier<T> supplier) {
+        long startTime = System.currentTimeMillis();
+        T result = supplier.get();
+        long elapsedTime = System.currentTimeMillis() - startTime;
+        log.info("{} Execution Time: {} ms", label, elapsedTime);
+        return result;
+    }
+}


### PR DESCRIPTION
### 설명
- 처음에는 하나의 `repository interface`에 대해 여러 구현체를 두고 DIP를 실현하고 싶었으나 원하는 대로 되지 않았습니다. 추후 필요한 구현체만 남기고 필요 없는 내용은 지울 예정입니다.
- Redis 분산락을 공통화하여 어노테이션만 적용할 수 있게 하려 했으나, 재고 처리를 기존의 비관적 락을 유지하는 방향으로 틀었습니다.

### **커밋 링크**
잔액 변동 낙관적 락 처리 및 동시성 테스트 : 3335088ebb8463a19b011e1c8da3e5779cf710ff
분산락 구현 및 쿠폰 발급 적용 : 9a506b16b214849f0a6b285f87326640c97f6a1b
쿠폰 발급 비관락과 분산락 성능 비교 테스트 : 2089036ddb65dfcae6f79a5223c3aeb8ac04b922

---
### **리뷰 포인트(질문)**
- Redis 분산락 모듈이 적절히 구현되었는지 궁금합니다.
> 1. 아키텍처에 맞게 DIP를 지키며 관심사를 잘 분리하였는지, 혹시 보완할 점은 없는지
> 2. 이번 과제 의도 중 하나가 DIP의 목적 중 infra 계층을 쉽게 변경할 수 있다(다른 계층을 수정할 필요가 없다)는 점을 체화하는 의도도 있다고 이해했는데, 현재 구현체 구현 방법이 그에 적절한지 (테스트용으로 구현체를 두 개 만들어서 주입 설정했는데 테스트 할 때는 이래도 되는지)
- `UserCoupon`을 조회하는 과정에서 `userCouponId`로 호출해야 하는데, repository 메서드 내 오타로 `couponId`로 호출하는 상황이 있었습니다. 그러나 테스트 케이스에서는 `couponId`와 `userCouponId`가 거의 동일하게 생성되었습니다. (테스트1에서 `couponId`=1일 때 `userCouponId`=1로 생성, 테스트2에서 `couponId`=2일 때 `userCouponId`=2로 생성하여, `userCouponId` 반환해야 할 걸 `couponId`로 반환해도 알 수 없음) 그래서 위와 같은 상황을 인지하지 못했고, 한참 뒤에 케이스가 깨지는 상황이 발생했습니다. 이런 상황을 방지하기 위해서는 어떤 식으로 테스트 케이스를 작성하는 게 좋을까요?
